### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "firebase": "^6.2.0",
     "install": "^0.12.2",
     "lodash.pick": "^4.4.0",
-    "npm": "^6.9.0",
     "react": "^16.8.3",
     "react-native": "^0.59.8",
     "react-native-background-timer": "^2.1.1",


### PR DESCRIPTION

Hello aishwaryakulkarni1!

It seems like you have npm as one of your (dev-) dependency in AdiClasses_map-Copy.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
